### PR TITLE
Handle recording of constraints using input names.

### DIFF
--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -349,8 +349,8 @@ class SqliteRecorder(CaseRecorder):
             if driver is None:
                 desvars = system.get_design_vars(True, get_sizes=False, use_prom_ivc=False)
                 responses = system.get_responses(True, get_sizes=False)
-                objectives = OrderedDict()
                 constraints = OrderedDict()
+                objectives = OrderedDict()
                 for name, data in responses.items():
                     if data['type'] == 'con':
                         constraints[name] = data
@@ -358,9 +358,9 @@ class SqliteRecorder(CaseRecorder):
                         objectives[name] = data
             else:
                 desvars = driver._designvars.copy()
+                responses = driver._responses.copy()
                 constraints = driver._cons.copy()
                 objectives = driver._objs.copy()
-                responses = driver._responses.copy()
 
             inputs = list(system.abs_name_iter('input', local=False, discrete=True))
             outputs = list(system.abs_name_iter('output', local=False, discrete=True))
@@ -395,8 +395,8 @@ class SqliteRecorder(CaseRecorder):
             for var_set, var_type in full_var_set:
                 for name in var_set:
 
-                    # Design variables can be requested by input name.
-                    if var_type == 'desvar':
+                    # Design variables, constraints and objectives can be requested by input name.
+                    if var_type != 'output':
                         name = var_set[name]['ivc_source']
 
                     if name not in self._abs2meta:

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -8,7 +8,6 @@ import sqlite3
 import numpy as np
 
 import openmdao.api as om
-from openmdao.recorders.case_reader import CaseReader
 
 from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node
 from openmdao.test_suite.components.ae_tests import AEComp
@@ -2633,7 +2632,7 @@ class TestSqliteRecorder(unittest.TestCase):
         with assert_warning(OMDeprecationWarning, msg):
             rec_mgr.record_metadata(None)
 
-    def test_cobyla_constraint(self):
+    def test_cobyla_constraints(self):
         prob = om.Problem()
         model = prob.model
 
@@ -2652,9 +2651,9 @@ class TestSqliteRecorder(unittest.TestCase):
         model.add_objective("f_xy")
 
         prob.setup()
-        t0, t1 = run_driver(prob)
+        prob.run_driver()
 
-        cr = CaseReader(self.filename)
+        cr = om.CaseReader(self.filename)
         case = cr.get_case(-1)
 
         dvs = case.get_design_vars()
@@ -2664,7 +2663,6 @@ class TestSqliteRecorder(unittest.TestCase):
         assert_near_equal(dvs, {'x': [6.66666669], 'y': [-7.33333338]}, tolerance=1e-8)
         assert_near_equal(con, {'x': [6.66666669], 'y': [-7.33333338]}, tolerance=1e-8)
         assert_near_equal(obj, {'f_xy': [-27.33333333]}, tolerance=1e-8)
-
 
 @use_tempdirs
 class TestFeatureSqliteRecorder(unittest.TestCase):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2633,6 +2633,10 @@ class TestSqliteRecorder(unittest.TestCase):
             rec_mgr.record_metadata(None)
 
     def test_cobyla_constraints(self):
+        """
+        When using the COBYLA optimizer, bounds are managed by adding constraints on input
+        variables. Check that SqliteRecorder and CaseReader handle this properly.
+        """
         prob = om.Problem()
         model = prob.model
 
@@ -2660,9 +2664,9 @@ class TestSqliteRecorder(unittest.TestCase):
         con = case.get_constraints()
         obj = case.get_objectives()
 
-        assert_near_equal(dvs, {'x': [6.66666669], 'y': [-7.33333338]}, tolerance=1e-8)
-        assert_near_equal(con, {'x': [6.66666669], 'y': [-7.33333338]}, tolerance=1e-8)
-        assert_near_equal(obj, {'f_xy': [-27.33333333]}, tolerance=1e-8)
+        assert_near_equal(dvs, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8)
+        assert_near_equal(con, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8)
+        assert_near_equal(obj, {'f_xy': -27.33333333}, tolerance=1e-8)
 
 @use_tempdirs
 class TestFeatureSqliteRecorder(unittest.TestCase):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2654,33 +2654,17 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.setup()
         t0, t1 = run_driver(prob)
 
-        print('iter:', prob.driver.iter_count)
-
         cr = CaseReader(self.filename)
-        cases = cr.list_cases('driver')
-        case = cr.get_case(cases[-1])
-        print(case)
+        case = cr.get_case(-1)
 
-        coordinate = [0, 'ScipyOptimize_COBYLA', (147, )]
+        dvs = case.get_design_vars()
+        con = case.get_constraints()
+        obj = case.get_objectives()
 
-        expected_desvars = {
-            "x": prob['x'],
-            "y": prob['y']
-        }
-        expected_objectives = {
-            "f_xy": prob['f_xy']
-        }
-        expected_constraints = {
-            "x": prob['x'],
-            "y": prob['y']
-        }
+        assert_near_equal(dvs, {'x': [6.66666669], 'y': [-7.33333338]}, tolerance=1e-8)
+        assert_near_equal(con, {'x': [6.66666669], 'y': [-7.33333338]}, tolerance=1e-8)
+        assert_near_equal(obj, {'f_xy': [-27.33333333]}, tolerance=1e-8)
 
-        expected_outputs = expected_desvars
-        expected_outputs.update(expected_objectives)
-        expected_outputs.update(expected_constraints)
-
-        expected_data = ((coordinate, (t0, t1), expected_outputs, None, None),)
-        assertDriverIterDataRecorded(self, expected_data, self.eps)
 
 @use_tempdirs
 class TestFeatureSqliteRecorder(unittest.TestCase):


### PR DESCRIPTION
### Summary

Handle recording of constraints that use input names, as is done when optimizing with COBYLA

### Related Issues

- Resolves #2304

### Backwards incompatibilities

None

### New Dependencies

None
