### PR TITLE
Fake3020

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -66,9 +66,9 @@ jobs:
           # test minimal install
           - NAME: Ubuntu Minimal
             OS: ubuntu-latest
-            PY: '3'
-            NUMPY: '1'
-            SCIPY: '1'
+            PY: '3.11'
+            NUMPY: '1.26'
+            SCIPY: '1.11'
             OPTIONAL: '[test]'
             TESTS: true
 


### PR DESCRIPTION
### Summary

Matrix free components can now declare partials purely for the purpose of specifying dependency, without allocating memory for a corresponding sub-jacobian.  
 
### Related Issues

- Resolves #3002

### Backwards incompatibilities

None

### New Dependencies

None
