### PR TITLE
Problem name update

### DIFF
--- a/.github/scripts/get_poem_id.py
+++ b/.github/scripts/get_poem_id.py
@@ -26,7 +26,7 @@ def get_poem_id(repository, pull_id):
     int
         0 if an associated POEM was identified, 1 if not and -1 if an error occurred.
     """
-    repository = 'OpenMDAO'  # FIXME: debugging
+    repository = 'OpenMDAO/OpenMDAO'  # FIXME: debugging
     print("-------------------------------------------------------------------------------")
     print(f"Checking Pull Request #{pull_id} on ${repository} for associated issue...")
     print("-------------------------------------------------------------------------------")

--- a/.github/scripts/get_poem_id.py
+++ b/.github/scripts/get_poem_id.py
@@ -26,14 +26,16 @@ def get_poem_id(repository, pull_id):
     int
         0 if an associated POEM was identified, 1 if not and -1 if an error occurred.
     """
+    repository = 'OpenMDAO'  # FIXME: debugging
     print("-------------------------------------------------------------------------------")
-    print(f"Checking Pull Request #{pull_id} for associated issue...")
+    print(f"Checking Pull Request #{pull_id} on ${repository} for associated issue...")
     print("-------------------------------------------------------------------------------")
     try:
-        pull_json = subprocess.check_output(["gh", "--repo", repository,
-                                             "issue", "view", "--json", "body", pull_id])
+        cmd = ["gh", "--repo", repository, "issue", "view", "--json", "body", pull_id]
+        print(f"{' '.join(cmd)}")
+        pull_json = subprocess.check_output(cmd)
     except subprocess.CalledProcessError as err:
-        print(f"Unable to access pull request #{pull_id}:\nrc={err.returncode}")
+        print(f"Unable to access pull request #{pull_id} on repository {repository}:\nrc={err.returncode}")
         return ERROR
 
     pull_body = json.loads(pull_json)["body"]
@@ -55,14 +57,15 @@ def get_poem_id(repository, pull_id):
         return NOT_FOUND
 
     print("-------------------------------------------------------------------------------")
-    print(f"Checking Issue #{issue_id} for associated POEM...")
+    print(f"Checking Issue #{issue_id} on ${repository} for associated POEM...")
     print("-------------------------------------------------------------------------------")
 
     try:
-        issue_json = subprocess.check_output(["gh", "--repo", repository,
-                                              "issue", "view", "--json", "body", issue_id])
+        cmd = ["gh", "--repo", repository, "issue", "view", "--json", "body", issue_id]
+        print(f"{' '.join(cmd)}")
+        issue_json = subprocess.check_output(cmd)
     except subprocess.CalledProcessError as err:
-        print(f"Unable to access issue  #{issue_id}:\nrc={err.returncode}")
+        print(f"Unable to access issue  #{issue_id} on repository {repository}:\nrc={err.returncode}")
         return ERROR
 
     issue_body = json.loads(issue_json)["body"]

--- a/.github/scripts/get_poem_id.py
+++ b/.github/scripts/get_poem_id.py
@@ -26,7 +26,6 @@ def get_poem_id(repository, pull_id):
     int
         0 if an associated POEM was identified, 1 if not and -1 if an error occurred.
     """
-    repository = 'OpenMDAO/OpenMDAO'  # FIXME: debugging
     print("-------------------------------------------------------------------------------")
     print(f"Checking Pull Request #{pull_id} on ${repository} for associated issue...")
     print("-------------------------------------------------------------------------------")
@@ -55,6 +54,8 @@ def get_poem_id(repository, pull_id):
     if not issue_id.isnumeric():
         # issue ID not found, could be blank or "N/A"
         return NOT_FOUND
+
+    repository = 'OpenMDAO/OpenMDAO'  # FIXME: debugging
 
     print("-------------------------------------------------------------------------------")
     print(f"Checking Issue #{issue_id} on ${repository} for associated POEM...")

--- a/.github/workflows/openmdao_update_poem.yml
+++ b/.github/workflows/openmdao_update_poem.yml
@@ -61,7 +61,7 @@ jobs:
               issue_number: ${{ github.event.number }},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '${{ env.POEM_MESSAGE }'
+              body: '${{ env.POEM_MESSAGE }}'
             })
 
       - name: Slack POEM message

--- a/.github/workflows/openmdao_update_poem.yml
+++ b/.github/workflows/openmdao_update_poem.yml
@@ -47,7 +47,7 @@ jobs:
           if python .github/scripts/get_poem_id.py ${GITHUB_REPOSITORY} $PR_NUMBER; then
             export POEM_MESSAGE=$(<POEM_MESSAGE.txt)
           fi
-          echo "POEM_MESSAGE=$POEM_MESSAGE >> $GITHUB_OUTPUT
+          echo "POEM_MESSAGE=$POEM_MESSAGE" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
         if: (github.event.action == 'opened' || github.event.action == 'reopened') && steps.check_for_poem.outputs.POEM_MESSAGE != ''

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -229,10 +229,9 @@ class Problem(object):
         # Set the Problem name so that it can be referenced from command line tools (e.g. check)
         # that accept a Problem argument, and to name the corresponding outputs subdirectory.
         if name:  # if name hasn't been used yet, use it. Otherwise, error
-            if name not in _problem_names:
-                self._name = name
-            else:
-                raise ValueError(f"The problem name '{name}' already exists")
+            if name in _problem_names:
+                issue_warning(f"The problem name '{name}' already exists")
+            self._name = name
         else:  # No name given: look for a name, of the form, 'problemN', that hasn't been used
             problem_counter = len(_problem_names) + 1 if _problem_names else ''
             base = _default_prob_name()

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -14,7 +14,7 @@ from openmdao.core.driver import Driver
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.misc_components import MultComp
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDerivativesConnected
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_totals
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_totals, assert_warnings
 import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
 from openmdao.utils.om_warnings import DerivativesWarning, OMDeprecationWarning, OpenMDAOWarning
@@ -777,6 +777,48 @@ class TestProblem(unittest.TestCase):
 
         prob.setup()
         prob.run_driver()
+
+        assert_near_equal(prob.get_val('x'), 0.0, 1e-5)
+        assert_near_equal(prob.get_val('y1'), 3.160000, 1e-2)
+        assert_near_equal(prob.get_val('y2'), 3.755278, 1e-2)
+        assert_near_equal(prob.get_val('z'), [1.977639, 0.000000], 1e-2)
+        assert_near_equal(prob.get_val('obj'), 3.18339395, 1e-2)
+
+    def test_duplicate_problem_name(self):
+
+        def _make_and_run():
+
+            prob = om.Problem(name='test_duplicate_prob_name', model=SellarDerivatives())
+            model = prob.model
+            model.nonlinear_solver = om.NonlinearBlockGS()
+
+            prob.driver = om.ScipyOptimizeDriver()
+            prob.driver.options['optimizer'] = 'SLSQP'
+            prob.driver.options['tol'] = 1e-9
+
+            model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
+            model.add_design_var('x', lower=0.0, upper=10.0)
+            model.add_objective('obj')
+            model.add_constraint('con1', upper=0.0)
+            model.add_constraint('con2', upper=0.0)
+
+            prob.setup()
+            prob.run_driver()
+
+            return prob
+
+        _make_and_run()
+
+        msg1 = "The problem name 'test_duplicate_prob_name' already exists"
+        
+        msg2 = ("A report with the name 'scaling' for instance "
+              "'test_duplicate_prob_name.driver' is already active.")
+
+        expected_warnings = [(OpenMDAOWarning, msg1),
+                             (OpenMDAOWarning, msg2)]
+
+        with assert_warnings(expected_warnings):
+            prob = _make_and_run()
 
         assert_near_equal(prob.get_val('x'), 0.0, 1e-5)
         assert_near_equal(prob.get_val('y1'), 3.160000, 1e-2)

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -18,7 +18,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_warning, asser
 import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
 from openmdao.utils.om_warnings import DerivativesWarning, OMDeprecationWarning, OpenMDAOWarning
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 from openmdao.utils.file_utils import get_work_dir
 from openmdao.utils.tests.test_hooks import hooks_active
 
@@ -784,11 +784,13 @@ class TestProblem(unittest.TestCase):
         assert_near_equal(prob.get_val('z'), [1.977639, 0.000000], 1e-2)
         assert_near_equal(prob.get_val('obj'), 3.18339395, 1e-2)
 
+    @set_env_vars(TESTFLO_RUNNING='0', OPENMDAO_REPORTS='scaling')
     def test_duplicate_problem_name(self):
 
         def _make_and_run():
 
-            prob = om.Problem(name='test_duplicate_prob_name', model=SellarDerivatives())
+            prob = om.Problem(name='test_duplicate_prob_name',
+                              model=SellarDerivatives())
             model = prob.model
             model.nonlinear_solver = om.NonlinearBlockGS()
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -17,7 +17,7 @@ from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDeriv
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_totals
 import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
-from openmdao.utils.om_warnings import DerivativesWarning, OMDeprecationWarning
+from openmdao.utils.om_warnings import DerivativesWarning, OMDeprecationWarning, OpenMDAOWarning
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.file_utils import get_work_dir
 from openmdao.utils.tests.test_hooks import hooks_active
@@ -2141,10 +2141,10 @@ class TestProblem(unittest.TestCase):
 
         om.Problem(name='prob_name2')
 
-        with self.assertRaises(ValueError) as e:
-            om.Problem(name='prob_name2')
+        msg = "The problem name 'prob_name2' already exists"
 
-        self.assertEqual(str(e.exception), "The problem name 'prob_name2' already exists")
+        with assert_warning(OpenMDAOWarning, msg):
+            om.Problem(name='prob_name2')
 
 
 @use_tempdirs
@@ -2495,9 +2495,10 @@ class NestedProblemTestCase(unittest.TestCase):
         p.model.connect('indep.x', 'G.comp.x')
         p.setup()
 
-        with self.assertRaises(Exception) as context:
+        msg = f"The problem name '{defname}' already exists"
+
+        with assert_warning(OpenMDAOWarning, msg):
             p.run_model()
-        self.assertEqual(str(context.exception), f"The problem name '{defname}' already exists")
 
         # If the first Problem uses the default name of 'problem2'
         openmdao.core.problem._clear_problem_names()  # need to reset these to simulate separate runs

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
@@ -10,7 +10,9 @@ except ImportError:
         def test_jupyter_book_docs(self):
             raise unittest.SkipTest("tests require the 'playwright' and 'aiounittest' packages.")
 else:
+    os.system("playwright install-deps")
     os.system("playwright install")
+
     from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs  # noqa: F401
 
 

--- a/openmdao/utils/reports_system.py
+++ b/openmdao/utils/reports_system.py
@@ -276,8 +276,9 @@ def activate_report(name, instance=None):
             return
 
     if (name, inst_id) in _active_reports:
-        raise ValueError(f"A report with the name '{name}' for instance '{inst_id}' is already "
-                         "active.")
+        issue_warning(f"A report with the name '{name}' for instance '{inst_id}' is already "
+                      "active.")
+        return
 
     report.register_hooks(instance)
     _active_reports.add((name, inst_id))

--- a/openmdao/utils/reports_system.py
+++ b/openmdao/utils/reports_system.py
@@ -274,6 +274,8 @@ def activate_report(name, instance=None):
             inst_id = _inst_id
         elif inst_id != _inst_id:  # registered inst_id doesn't match current instance
             return
+        
+    print(_active_reports)
 
     if (name, inst_id) in _active_reports:
         issue_warning(f"A report with the name '{name}' for instance '{inst_id}' is already "

--- a/openmdao/utils/reports_system.py
+++ b/openmdao/utils/reports_system.py
@@ -274,8 +274,6 @@ def activate_report(name, instance=None):
             inst_id = _inst_id
         elif inst_id != _inst_id:  # registered inst_id doesn't match current instance
             return
-        
-    print(_active_reports)
 
     if (name, inst_id) in _active_reports:
         issue_warning(f"A report with the name '{name}' for instance '{inst_id}' is already "

--- a/openmdao/visualization/n2_viewer/tests/test_gui.py
+++ b/openmdao/visualization/n2_viewer/tests/test_gui.py
@@ -9,6 +9,7 @@ except ImportError:
         def test_n2_gui(self):
             raise unittest.SkipTest("tests require the 'playwright' package.")
 else:
+    os.system("playwright install-deps")
     os.system("playwright install")
     from .n2_gui_test import n2_gui_test_case  # noqa: F401
     from .gen_gui_test import gen_gui_test_case  # noqa: F401


### PR DESCRIPTION
### Summary

In notebook environments, running a cell repeatedly would create a new problem instance (with a new name) each time.
This causes the number of output directories to balloon.
To fix this, one can name the problem something specific so that it always has the same output directory name, but OpenMDAO was currently set to raise an error if two problems ever had the same name.

This change makes it so that having multiple problems with the same name will result in a warning, rather than a hard error.

### Related Issues

- Resolves #3339 

### Backwards incompatibilities

None

### New Dependencies

None
